### PR TITLE
Create AWS resource configurations for Terraform S3 backend state storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.terraform.lock.hcl

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,10 @@
+resource "aws_s3_bucket" "terraform_state_store" {
+  bucket = "jl-terraform-remote-state-store"
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state_store" {
+  bucket = aws_s3_bucket.terraform_state_store.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,3 +8,14 @@ resource "aws_s3_bucket_versioning" "terraform_state_store" {
     status = "Enabled"
   }
 }
+
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name         = "terraform_state_lock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">=1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.35.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "ap-southeast-1"
+  profile = "bball8bot-admin"
+}


### PR DESCRIPTION
This diff creates Terraform configurations for the following AWS resources:
- S3 bucket: `jl-terraform-remote-state-store`
- DynamoDB: `terraform-state-lock`

These resources will be used to store Terraform configurations for the entire AWS account.
1. The S3 bucket will be the store for the Terraform state files.
2. The DynamoDB table will enable state locking.