### PR TITLE
Provision DynamoDB table for Terraform state locking

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,3 +8,14 @@ resource "aws_s3_bucket_versioning" "terraform_state_store" {
     status = "Enabled"
   }
 }
+
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name         = "terraform_state_lock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}


### PR DESCRIPTION
This diff creates the Terraform resource configuration for a DynamoDB table that will be used for Terraform state locking.