### PR TITLE
Migrate workspace state to S3

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -7,9 +7,17 @@ terraform {
       version = "5.35.0"
     }
   }
+
+  backend "s3" {
+    region = "ap-southeast-1"
+
+    bucket = "jl-terraform-remote-state-store"
+    key    = "bball8bot/terraform.tfstate"
+
+    dynamodb_table = "terraform_state_lock"
+  }
 }
 
 provider "aws" {
-  region  = "ap-southeast-1"
-  profile = "bball8bot-admin"
+  region = "ap-southeast-1"
 }


### PR DESCRIPTION
This diff updates the provider configuration of this repo's Terraform workspace, to store state in the provisioned S3 bucket.