### PR TITLE
Update S3 state file key

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,7 +12,7 @@ terraform {
     region = "ap-southeast-1"
 
     bucket = "jl-terraform-remote-state-store"
-    key    = "terraform-s3-state-store-infra/terraform.tfstate"
+    key    = "account-wide-terraform-support/terraform.tfstate"
 
     dynamodb_table = "terraform_state_lock"
   }


### PR DESCRIPTION
Yet another update of S3 state key.

Supersedes #7 and #8 (was rolled back, committed onto outdated `develop` branch).