### PR TITLE
Create repo-specific CI IAM policy and role

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -26,3 +26,49 @@ data "aws_iam_policy_document" "terraform_s3_state_store_policy" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "account_wide_terraform_support_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
+    ]
+
+    resources = [
+      aws_iam_openid_connect_provider.github.arn
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:CreatePolicy",
+      "iam:DeletePolicy",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "assume_account_wide_terraform_support_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.github_oidc_provider_url}:sub"
+      values = [
+        "repo:jonleeyz/terraform-backend:*",
+      ]
+    }
+
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::574182556674:oidc-provider/${local.github_oidc_provider_url}"]
+    }
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -7,3 +7,23 @@ resource "aws_iam_policy" "terraform_s3_state_store" {
     prevent_destroy = true
   }
 }
+
+resource "aws_iam_policy" "account_wide_terraform_support" {
+  name   = "accountWideTerraformSupportPolicy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.account_wide_terraform_support_policy.json
+}
+
+resource "aws_iam_role" "account_wide_terraform_support" {
+  name               = "accountWideTerraformSupportRole"
+  assume_role_policy = data.aws_iam_policy_document.assume_account_wide_terraform_support_role.json
+  managed_policy_arns = [
+    aws_iam_policy.terraform_s3_state_store.arn,
+    aws_iam_policy.account_wide_terraform_support.arn
+  ]
+}
+
+output "ci_iam_role_arn" {
+  description = "The ARN of the IAM role that the repo's CI workflow will attempt to assume"
+  value = aws_iam_role.account_wide_terraform_support.arn
+}


### PR DESCRIPTION
To enable GitHub pushes and PR triggered workflows that will run `terraform plan` and `apply`, the below resources need to be provisioned:

---

This diff creates Terraform configurations for the following AWS resources:
- IAM policy: `accountWideTerraformSupportPolicy`
  - Specific to the workflow for this repo: Enables permissions for all resources provisioned thus far.
- IAM role: `accountWideTerraformSupportRole`
  - The above policy is attached, as well as the common Terraform state management IAM policy previously provisioned: `terraformS3StateStorePolicy`.
  - This role allows GitHub pushes and PRs to trigger CI workflows in this repo that will run `terraform plan` and `apply`.