### PR TITLE
Remove S3 provider information

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -9,11 +9,6 @@ terraform {
   }
 
   backend "s3" {
-    region = "ap-southeast-1"
-
-    bucket = "jl-terraform-remote-state-store"
-    key    = "account-wide-terraform-support/terraform.tfstate"
-
     dynamodb_table = "terraform_state_lock"
   }
 }


### PR DESCRIPTION
This diff removes the S3 provider information, so that it can be provided through script (local execution) or through GitHub Secrets.

Ref: https://developer.hashicorp.com/terraform/language/settings/backends/configuration#partial-configuration