### PR TITLE
Update IAM policies and role

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -29,7 +29,28 @@ data "aws_iam_policy_document" "terraform_state_management_policy" {
   }
 }
 
-data "aws_iam_policy_document" "account_wide_terraform_support_policy" {
+data "aws_iam_policy_document" "workspace_infra_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBuckets",
+      "s3:CreateBucket",
+      "s3:DeleteBucket"
+    ]
+
+    resources = ["*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:ListTables",
+      "dynamodb:DescribeTable",
+      "dynamodb:CreateTable",
+      "dynamodb:DeleteTable"
+    ]
+
+    resources = ["*"]
+  }
   statement {
     effect = "Allow"
     actions = [

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "terraform_state_management_policy" {
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["s3:ListBucket"]
 
     resources = [aws_s3_bucket.terraform_state_store.arn]

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,21 +1,23 @@
-data "aws_iam_policy_document" "terraform_s3_state_store_policy" {
+data "aws_iam_policy_document" "terraform_state_management_policy" {
   statement {
     effect = "Allow"
-    actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:ListBucket"
-    ]
+    actions = ["s3:ListBucket"]
 
-    resources = [
-      aws_s3_bucket.terraform_state_store.arn,
-      "${aws_s3_bucket.terraform_state_store.arn}/*"
-    ]
+    resources = [aws_s3_bucket.terraform_state_store.arn]
   }
   statement {
     effect = "Allow"
     actions = [
-      "dynamodb:ListTables",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+
+    resources = ["${aws_s3_bucket.terraform_state_store.arn}/${local.workspace_bucket_key}"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
       "dynamodb:GetItem",
       "dynamodb:PutItem",
       "dynamodb:DeleteItem"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,7 +1,7 @@
-resource "aws_iam_policy" "terraform_s3_state_store" {
-  name   = "terraformS3StateStorePolicy"
+resource "aws_iam_policy" "terraform_state_management" {
+  name   = "accountWideTerraformSupport_TerraformStateManagementPolicy"
   path   = "/"
-  policy = data.aws_iam_policy_document.terraform_s3_state_store_policy.json
+  policy = data.aws_iam_policy_document.terraform_state_management_policy.json
 
   lifecycle {
     prevent_destroy = true
@@ -18,7 +18,7 @@ resource "aws_iam_role" "account_wide_terraform_support" {
   name               = "accountWideTerraformSupportRole"
   assume_role_policy = data.aws_iam_policy_document.assume_account_wide_terraform_support_role.json
   managed_policy_arns = [
-    aws_iam_policy.terraform_s3_state_store.arn,
+    aws_iam_policy.terraform_state_management.arn,
     aws_iam_policy.account_wide_terraform_support.arn
   ]
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -3,15 +3,15 @@ resource "aws_iam_policy" "terraform_state_management" {
   path   = "/"
   policy = data.aws_iam_policy_document.terraform_state_management_policy.json
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  description = "This policy allows the user / role to manage Terraform state for the accountWideTerraformSupport workspace."
 }
 
 resource "aws_iam_policy" "repo_infra" {
   name   = "accountWideTerraformSupport_InfraPolicy"
   path   = "/"
   policy = data.aws_iam_policy_document.workspace_infra_policy.json
+
+  description = "This policy will be used to manage infrastructure that supports S3 Terrform state management and associated CI workflows for the entire account."
 }
 
 resource "aws_iam_role" "repo_ci" {
@@ -21,6 +21,8 @@ resource "aws_iam_role" "repo_ci" {
     aws_iam_policy.terraform_state_management.arn,
     aws_iam_policy.repo_infra.arn
   ]
+
+  description = "This role will be used to execute GitHub Actions workflows that will create Terraform plans and apply them."
 }
 
 output "ci_iam_role_arn" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -25,5 +25,5 @@ resource "aws_iam_role" "repo_ci" {
 
 output "ci_iam_role_arn" {
   description = "The ARN of the IAM role that the repo's CI workflow will attempt to assume"
-  value = aws_iam_role.repo_ci.arn
+  value       = aws_iam_role.repo_ci.arn
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -8,22 +8,22 @@ resource "aws_iam_policy" "terraform_state_management" {
   }
 }
 
-resource "aws_iam_policy" "account_wide_terraform_support" {
-  name   = "accountWideTerraformSupportPolicy"
+resource "aws_iam_policy" "repo_infra" {
+  name   = "accountWideTerraformSupport_InfraPolicy"
   path   = "/"
-  policy = data.aws_iam_policy_document.account_wide_terraform_support_policy.json
+  policy = data.aws_iam_policy_document.workspace_infra_policy.json
 }
 
-resource "aws_iam_role" "account_wide_terraform_support" {
-  name               = "accountWideTerraformSupportRole"
+resource "aws_iam_role" "repo_ci" {
+  name               = "accountWideTerraformSupport_CIRole"
   assume_role_policy = data.aws_iam_policy_document.assume_account_wide_terraform_support_role.json
   managed_policy_arns = [
     aws_iam_policy.terraform_state_management.arn,
-    aws_iam_policy.account_wide_terraform_support.arn
+    aws_iam_policy.repo_infra.arn
   ]
 }
 
 output "ci_iam_role_arn" {
   description = "The ARN of the IAM role that the repo's CI workflow will attempt to assume"
-  value = aws_iam_role.account_wide_terraform_support.arn
+  value = aws_iam_role.repo_ci.arn
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,3 +1,4 @@
 locals {
   github_oidc_provider_url = "token.actions.githubusercontent.com"
+  workspace_bucket_key = "account-wide-terraform-support/terraform.tfstate"
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,4 +1,4 @@
 locals {
   github_oidc_provider_url = "token.actions.githubusercontent.com"
-  workspace_bucket_key = "account-wide-terraform-support/terraform.tfstate"
+  workspace_bucket_key     = "account-wide-terraform-support/terraform.tfstate"
 }


### PR DESCRIPTION
The following IAM policies and role are updated in this diff:

- The Terraform state management policy has been redesigned to be scoped only to this specific workspace's bucket key.
- For every workspace that wants to manage state through the centrally provisioned S3 state management infrastructure, a new policy will have to be defined, that scopes specifically to that workspace's bucket key.

- To enable this repo in particular to manage the centrally provisioned S3 state management infrastructure, the repo infra policy has been updated to include create and delete permissions respectively.

- Descriptions have been added to the policies and role to disambiguate.