### PR TITLE
Expand infra IAM policy scope

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -33,44 +33,9 @@ data "aws_iam_policy_document" "workspace_infra_policy" {
   statement {
     effect = "Allow"
     actions = [
-      "s3:ListBuckets",
-      "s3:CreateBucket",
-      "s3:DeleteBucket"
-    ]
-
-    resources = ["*"]
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "dynamodb:ListTables",
-      "dynamodb:DescribeTable",
-      "dynamodb:CreateTable",
-      "dynamodb:DeleteTable"
-    ]
-
-    resources = ["*"]
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "iam:CreateOpenIDConnectProvider",
-      "iam:DeleteOpenIDConnectProvider",
-    ]
-
-    resources = [
-      aws_iam_openid_connect_provider.github.arn
-    ]
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "iam:CreateRole",
-      "iam:DeleteRole",
-      "iam:CreatePolicy",
-      "iam:DeletePolicy",
-      "iam:AttachRolePolicy",
-      "iam:DetachRolePolicy"
+      "s3:*",
+      "dynamodb:*",
+      "iam:*"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
More widespread permissions are required to ensure Terraform can `plan` and `apply` during the CI workflow.

Re-commital of #20, which was done without a squash and merge.