### PR TITLE
Create PR comment triggered CI workflow

### DIFF
--- a/.github/workflows/plan_and_apply_on_pr_comment.yml
+++ b/.github/workflows/plan_and_apply_on_pr_comment.yml
@@ -11,7 +11,7 @@ env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
 jobs:
   terraform-plan-on-pr-comment:
-    if: contains(github.event.comment.body, 'terraform plan')
+    if: github.event.issue.pull_request
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/plan_and_apply_on_pr_comment.yml
+++ b/.github/workflows/plan_and_apply_on_pr_comment.yml
@@ -1,0 +1,134 @@
+name: "CI/CD: On PR comment"
+on:
+  issue_comment:
+    types: [created]
+permissions:
+      id-token: write       # Required for AWS OIDC connection
+      contents: read        # Required by actions/checkout
+      pull-requests: write  # Required by GitHub bot to create comments on PRs
+env:
+  TF_LOG: INFO
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+jobs:
+  terraform-plan-on-pr-comment:
+    if: contains(github.event.comment.body, 'terraform plan')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./terraform
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v3
+
+      - name: Assume CI AWS IAM role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: GitHub-OIDC-TERRAFORM
+
+      - name: Install Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: terraform fmt
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: terraform init
+        id: init
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}"
+
+      - name: terraform validate
+        id: validate
+        run: terraform validate
+
+      - name: terraform plan
+        id: plan
+        run: terraform plan -input=false
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+
+      - name: Report workflow output
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let output = `### CI workflow: Terraform plan
+
+            Commit: ${{ github.sha }}
+            Pushed by: @${{ github.actor }}
+            Action: \`${{ github.event_name }}\`
+
+            ---
+
+            1. \`terraform fmt\`: ️ \`${{ steps.fmt.outcome }}\`
+            2. \`terraform init\`:  \`${{ steps.init.outcome }}\`
+            3. \`terraform validate\`:  \`${{ steps.validate.outcome }}\`
+            4. \`terraform plan\`:  \`${{ steps.plan.outcome }}\`
+
+            <details open><summary>Generated plan:</summary>
+
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            ---
+
+            `;
+
+            output = output.replace(/success/g, "success ✅")
+            output = output.replace(/failure/g, "failure ❌")
+
+            const debugInfo = `### Debug information
+
+            <details><summary>terraform fmt:</summary>
+
+            \`\`\`
+            ${{ steps.fmt.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            \n
+
+            <details><summary>terraform init:</summary>
+
+            \`\`\`
+            ${{ steps.init.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            \n
+
+            <details><summary>terraform validate:</summary>
+
+            \`\`\`
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+           
+            </details>
+
+            ---
+            Comment \`terraform plan\` to regenerate the plan.
+            Comment \`terraform apply\` to apply the generated plan.
+            `;
+
+            output = output.concat(debugInfo)
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })


### PR DESCRIPTION
This diff adds a workflow that will trigger `terraform plan` or `apply` if a `/terraform plan` or `terraform apply` comment is made on a PR.

Currently not working, workflow is not triggering at all; might be an issue with the `on` condition.