### PR TITLE
Update configure-aws-credentials step version in PR creation CI workflow

### DIFF
--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Assume CI AWS IAM role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
To remove `out-of-date` node warnings. v1 is pretty old as well