### PR TITLE
Migrate Terraform state lock table config into GitHub secrets

### DIFF
--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -41,7 +41,8 @@ jobs:
         env:
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
           AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME }}
-        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}"
+          AWS_STATE_LOCK_TABLE_NAME: ${{ secrets.AWS_STATE_LOCK_TABLE_NAME }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}" -backend-config="dynamodb_table=${AWS_STATE_LOCK_TABLE_NAME}"
 
       - name: terraform validate
         id: validate

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -9,7 +9,6 @@ terraform {
   }
 
   backend "s3" {
-    dynamodb_table = "terraform_state_lock"
   }
 }
 


### PR DESCRIPTION
This diff migrates the state lock table backend configuration from local file in providers.tf to GitHub Secrets.