### PR TITLE
Add ARN outputs for global state management infrastructure

### DIFF
--- a/terraform/global_state_management_support.tf
+++ b/terraform/global_state_management_support.tf
@@ -37,3 +37,19 @@ resource "aws_iam_openid_connect_provider" "github" {
   ]
   thumbprint_list = ["1b511abead59c6ce207077c0bf0e0043b1382612"]
 }
+
+output "terraform_state_store_bucket_arn" {
+  value       = aws_s3_bucket.terraform_state_store.arn
+  description = "The ARN of the provisioned S3 bucket that will store state for all Terraform workspaces associated with this AWS account"
+}
+
+output "terraform_state_lock_table_arn" {
+  value       = aws_dynamodb_table.terraform_state_lock.arn
+  description = "The ARN of the provisioned DynamoDB table that will perform state locking for all Terraform workspaces associated with this AWS account"
+}
+
+output "oidc_iam_provider_arn" {
+  value       = aws_dynamodb_table.terraform_state_lock.arn
+  description = "The ARN of the provisioned OpenID Connect IAM Provider that will allow requests from GitHub to assume IAM roles"
+}
+

--- a/terraform/global_state_management_support.tf
+++ b/terraform/global_state_management_support.tf
@@ -49,7 +49,7 @@ output "terraform_state_lock_table_arn" {
 }
 
 output "oidc_iam_provider_arn" {
-  value       = aws_dynamodb_table.terraform_state_lock.arn
+  value       = aws_iam_openid_connect_provider.github.arn
   description = "The ARN of the provisioned OpenID Connect IAM Provider that will allow requests from GitHub to assume IAM roles"
 }
 

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -1,0 +1,5 @@
+export AWS_BUCKET_NAME="jl-terraform-remote-state-store"
+export AWS_BUCKET_KEY_NAME="account-wide-terraform-support/terraform.tfstate"
+export AWS_REGION="ap-southeast-1"
+
+terraform init -migrate-state -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}"


### PR DESCRIPTION
This diff adds ARN outputs for the following provisioned infrastructure that supports global state management across-AWS-account.