### PR TITLE
Fix CI reporting step

### DIFF
--- a/.github/workflows/plan_on_pr.yml
+++ b/.github/workflows/plan_on_pr.yml
@@ -50,12 +50,10 @@ jobs:
       - name: terraform plan
         id: plan
         run: terraform plan -input=false
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
 
       - name: Report workflow output
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
+        if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
This diff fixes logical errors in the CI reporting step in the PR-creation-triggered CI workflow.

---

Previously, if the `terraform plan` in the workflow failed due to a failure to generate a plan:
- UNEXPECTED: The step's outcome indicated success in the GitHub workflow UI.
- UNEXPECTED: The overall workflow status indicated success.
- EXPECTED: The step's outcome was indicated as a failure in the generated comment report on the PR.

Expected: 
- The step's outcome should indicate failure in the GitHub workflow UI.
- The overall workflow status should indicate failure.
- The step's outcome was indicated as a failure in the generated comment report on the PR.