### PR TITLE
Update apply on push CI workflow to provide terraform state lock table config

### DIFF
--- a/.github/workflows/apply_on_plan.yml
+++ b/.github/workflows/apply_on_plan.yml
@@ -43,7 +43,8 @@ jobs:
         env:
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
           AWS_BUCKET_KEY_NAME: ${{ secrets.AWS_BUCKET_KEY_NAME }}
-        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}"
+          AWS_STATE_LOCK_TABLE_NAME: ${{ secrets.AWS_STATE_LOCK_TABLE_NAME }}
+        run: terraform init -backend-config="bucket=${AWS_BUCKET_NAME}" -backend-config="key=${AWS_BUCKET_KEY_NAME}" -backend-config="region=${AWS_REGION}" -backend-config="dynamodb_table=${AWS_STATE_LOCK_TABLE_NAME}"
 
       - name: terraform validate
         id: validate


### PR DESCRIPTION
This diff adds on to #27, by updating the apply on push CI workflow accordingly as well.

---

The Terraform state lock table config needs to be included in the `terraform init` step of any workflow to enable state locking for that workflow.